### PR TITLE
Add documentation

### DIFF
--- a/doc/api-calls.md
+++ b/doc/api-calls.md
@@ -1,0 +1,2 @@
+
+[comment]: # document the API calls with their parameters and return values

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -1,0 +1,92 @@
+The data model consists of ten models
+* `Affiliation` - information about which facility a member is located at
+* `Dataset` - information about an experimental run, including optional File, Sample, Instrument and Technique
+* `Document` - proposal which includes the dataset or published paper which references the dataset
+* `File` - name of file and optionally location
+* `Instrument` - beam line where experiment took place
+* `Member` - proposal team member or paper co-author
+* `Parameter` - scalar measurement with value and units
+* `Person` - human who carried out experiment
+* `Role` - operator, author
+* `Sample` - extract of material used in the experiment
+* `Technique` - common name of scientific method used
+
+
+https://confluence.panosc.eu/display/wp3/Data+Model
+## Affiliation
+
+The `Affiliation` model has five optional fields
+* Id (string)
+* Name (string)
+* Address (string)
+* City (string)
+* Country (string)
+
+## Dataset
+The `Dataset` model consists of 4 mandatory fields
+* Persistent Identifier or PID (string)
+* Title (string)
+* creation date (date)
+* isPublic (boolean)
+
+and an optional field
+* size (measurement with units(bytes))
+
+The `Dataset` can have one `Instrument` only and several `Techniques`, `Parameters`, `Files` and `Samples`
+
+## Document
+The `Document` model represents a scientific proposal or publication. It can include `Datasets`, `Parameters` and `Members`.
+It has three mandatory fields
+* PID
+* Type
+* title
+
+and seven optional fields
+* internal (Boolean)
+* summary (String)
+* DOI (string)
+* Start date (date)
+* end date (date)
+* release date (date)
+* license (string, e.g. CC-BY-4.0)
+
+## File
+
+The `File` model has two mandatory fields,
+* Id
+* name
+
+and two optional
+* path 
+* size
+
+## Instrument
+
+The `Instrument` model has three mandatory fields, 
+* ID (string, e.g. a DOI)
+* Name (String, e.g. Loki)
+* Facility (string e.g. ESS)
+
+## Member
+
+## Parameter
+
+The `Parameter` model is intended for scientific measurements. It has two mandatory fields
+* name (string, e.g. sample_pressure)
+* value (number e.g 22)
+
+and one mandatory where applicable field
+* units (string e.g. bar)
+
+## Person
+
+## Role
+
+
+## Technique
+The `Technique` model has two mandatory fields
+* PID (string)
+* name (string) 
+
+
+In general the API is readonly with no DELETE, POST/PUT or PATCH requests.

--- a/doc/query.md
+++ b/doc/query.md
@@ -1,0 +1,2 @@
+
+[comment]: # document the query syntax for the search calls


### PR DESCRIPTION
I suggest that we should start writing documentation for the search API.  Mostly in order to define a specification that the API must meet in the end.  For the beginning, I guess simple markdown files will do. One may add more sophisticated document generators to get nice HTML output later on.

I suggest the documentation should be in the code tree rather then in the wiki, because:

- it will then be versioned together with the code.
- it allows us to open issues and pull requests to amend the documentation and to discuss changes.

This PR starts mostly empty, only having the data model copied verbatim from the wiki. I suggest that we must at least document:

- the data model,
- the API calls, and
- the query syntax.

Therefore I add empty files for the latter two.  If accepted, I might submit further PRs to add content.