### PR TITLE
Document API calls

### DIFF
--- a/doc/api-calls.md
+++ b/doc/api-calls.md
@@ -1,2 +1,218 @@
+# The search API calls
 
-[comment]: # document the API calls with their parameters and return values
+## Dataset
+
+### Get metadata
+
+Get extended metadata for a dataset.
+
+#### Call
+
+`GET /datasets/{id}/metadata`
+
+#### Path parameters
+
+id
+: the id of the dataset
+
+#### Query parameters
+
+TBD
+
+#### Returns
+
+TBD
+
+### Get dataset
+
+Get a single dataset.
+
+#### Call
+
+`GET /datasets/{id}`
+
+#### Path parameters
+
+id
+: the id of the dataset
+
+#### Returns
+
+The dataset
+
+### Search datasets
+
+Search for datasets.
+
+#### Call
+
+`GET /datasets`
+
+#### Query parameters
+
+filter
+: a query
+
+#### Returns
+
+A list of datasets.
+
+## Document
+
+### Count documents
+
+Get the number of documents.
+
+#### Call
+
+`GET /documents/count`
+
+#### Query parameters
+
+where
+: a query
+
+#### Returns
+
+A number
+
+### Get document
+
+Get a single document.
+
+#### Call
+
+`GET /documents/{id}`
+
+#### Path parameters
+
+id
+: the id of the document
+
+#### Returns
+
+The document
+
+### Search documents
+
+Search for documents.
+
+#### Call
+
+`GET /documents`
+
+#### Query parameters
+
+filter
+: a query
+
+#### Returns
+
+A list of documents.
+
+## Instrument
+
+### Count instruments
+
+Get the number of instruments.
+
+#### Call
+
+`GET /instruments/count`
+
+#### Query parameters
+
+where
+: a query
+
+#### Returns
+
+A number
+
+### Get instrument
+
+Get a single instrument.
+
+#### Call
+
+`GET /instruments/{id}`
+
+#### Path parameters
+
+id
+: the id of the instrument
+
+#### Returns
+
+The instrument
+
+### Search instruments
+
+Search for instruments.
+
+#### Call
+
+`GET /instruments`
+
+#### Query parameters
+
+filter
+: a query
+
+#### Returns
+
+A list of instruments.
+
+## Sample
+
+### Count samples
+
+Get the number of samples.
+
+#### Call
+
+`GET /samples/count`
+
+#### Query parameters
+
+where
+: a query
+
+#### Returns
+
+A number
+
+### Get sample
+
+Get a single sample.
+
+#### Call
+
+`GET /samples/{id}`
+
+#### Path parameters
+
+id
+: the id of the sample
+
+#### Returns
+
+The sample
+
+### Search samples
+
+Search for samples.
+
+#### Call
+
+`GET /samples`
+
+#### Query parameters
+
+filter
+: a query
+
+#### Returns
+
+A list of samples.
+

--- a/doc/api-calls.md
+++ b/doc/api-calls.md
@@ -23,6 +23,8 @@ TBD
 
 TBD
 
+---
+
 ### Get dataset
 
 Get a single dataset.
@@ -40,6 +42,8 @@ id
 
 The dataset
 
+---
+
 ### Search datasets
 
 Search for datasets.
@@ -56,6 +60,8 @@ filter
 #### Returns
 
 A list of datasets.
+
+---
 
 ## Document
 
@@ -76,6 +82,8 @@ where
 
 A number
 
+---
+
 ### Get document
 
 Get a single document.
@@ -93,6 +101,8 @@ id
 
 The document
 
+---
+
 ### Search documents
 
 Search for documents.
@@ -109,6 +119,8 @@ filter
 #### Returns
 
 A list of documents.
+
+---
 
 ## Instrument
 
@@ -129,6 +141,8 @@ where
 
 A number
 
+---
+
 ### Get instrument
 
 Get a single instrument.
@@ -146,6 +160,8 @@ id
 
 The instrument
 
+---
+
 ### Search instruments
 
 Search for instruments.
@@ -162,6 +178,8 @@ filter
 #### Returns
 
 A list of instruments.
+
+---
 
 ## Sample
 
@@ -182,6 +200,8 @@ where
 
 A number
 
+---
+
 ### Get sample
 
 Get a single sample.
@@ -198,6 +218,8 @@ id
 #### Returns
 
 The sample
+
+---
 
 ### Search samples
 

--- a/doc/api-calls.md
+++ b/doc/api-calls.md
@@ -1,5 +1,15 @@
 # The search API calls
 
+## General remarks
+
+* In a first approach, we define an API without authentication.  As a
+  consequence, this API will be constraint to the read only access to
+  public data.  Later on, we will add authentication to allow also
+  access to embargoed data and may also consider to allow the creation
+  of new datasets.
+
+---
+
 ## Dataset
 
 ### Get metadata


### PR DESCRIPTION
Add documentation of the API calls with their paths, parameters, and returns.

This is not yet finalized. As a starting point, I tried to describe the calls that are currently implemented in the API as displayed in the API explorer. But there are still many things to discuss. I open this PR also to create a place for this discussion.

The API calls are closely related to the query syntax. @garethcmurphy, since you implemented the queries in the API, would you mind providing a corresponding (starting point of a) documentation of the query syntax? I suggest that we need to discuss both in parallel.