### PR TITLE
Document the  data model

### DIFF
--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -40,9 +40,9 @@ Information about which facility a member is located at.
 
 ### Relationships
 
-| Card | Class  | Field  |
-| ---- | ------ | ------ |
-| 1,1  | Member | member |
+| Card | Class  | Field |
+| ---- | ------ | ----- |
+| 1,1  | Member |       |
 
 ### Properties
 
@@ -120,9 +120,9 @@ Name of file and optionally location.
 
 ### Relationships
 
-| Card | Class   | Field   |
-| ---- | ------- | ------- |
-| 1,1  | Dataset | dataset |
+| Card | Class   | Field |
+| ---- | ------- | ----- |
+| 1,1  | Dataset |       |
 
 ### Properties
 
@@ -163,7 +163,7 @@ Proposal team member or paper co-author.
 
 | Card | Class       | Field        |
 | ---- | ----------- | ------------ |
-| 1,1  | Document    | document     |
+| 1,1  | Document    |              |
 | 1,1  | Person      | person       |
 | 0.*  | Affiliation | affiliations |
 
@@ -179,10 +179,10 @@ Proposal team member or paper co-author.
 
 ### Relationships
 
-| Card | Class       | Field        |
-| ---- | ----------- | ------------ |
-| 0,1  | Dataset     | dataset      |
-| 0,1  | Document    | document     |
+| Card | Class       | Field |
+| ---- | ----------- | ----- |
+| 0,1  | Dataset     |       |
+| 0,1  | Document    |       |
 
 Note: a parameter is either related to a dataset or a document, but
 not both.
@@ -203,9 +203,9 @@ Human who carried out experiment.
 
 ### Relationships
 
-| Card | Class  | Field   |
-| ---- | ------ | ------- |
-| 0,*  | Member | members |
+| Card | Class  | Field |
+| ---- | ------ | ----- |
+| 0,*  | Member |       |
 
 ### Properties
 
@@ -245,9 +245,9 @@ Common name of scientific method used.
 
 ### Relationships
 
-| Card | Class   | Field    |
-| ---- | ------- | -------- |
-| 0,*  | Dataset | datasets |
+| Card | Class   | Field |
+| ---- | ------- | ----- |
+| 0,*  | Dataset |       |
 
 ### Properties
 

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -1,6 +1,6 @@
 # The data model
 
-The data model consists of ten models
+The data model consists of ten classes
 * `Affiliation` - information about which facility a member is located at
 * `Dataset` - information about an experimental run, including optional File, Sample, Instrument and Technique
 * `Document` - proposal which includes the dataset or published paper which references the dataset
@@ -13,6 +13,24 @@ The data model consists of ten models
 * `Technique` - common name of scientific method used
 
 https://confluence.panosc.eu/display/wp3/Data+Model
+
+## General remarks
+
++ Classes that may be returned by API calls have a `id` property
+  allowing to refer to them in subsequent calls like `GET /datasets/{id}`.
+  This id is a purely internal identifier of the local metadata
+  catalogue.  It is considered ephemeral and should not be retained by
+  the client beyond the current session.  The value should be
+  restricted to the characters `0-9A-Za-z_.~-`.
+
++ Some classes have a `pid` property.  This is a persistent identifier
+  that is supposed to be stable and may be stored in the client for
+  later referal.  It also allows cross references to objects in remote
+  repositories.  The value should be a well established persistent
+  identifier such as a DOI, a Handle, an ORCID-iD, or a ROR.  If such
+  a PID is not available for the object, a locally assigned identifier
+  in the metadata catalogue is acceptable, as long as it is guaranteed
+  to be stable.
 
 ---
 
@@ -30,7 +48,7 @@ Information about which facility a member is located at.
 
 | Field   | Type   | Mandatory | Comment |
 | ------- | ------ | --------- | ------- |
-| id      | String | no        |         |
+| pid     | String | no        |         |
 | name    | String | no        |         |
 | address | String | no        |         |
 | city    | String | no        |         |
@@ -58,10 +76,11 @@ Sample, Instrument and Technique.
 
 | Field        | Type    | Mandatory | Comment                      |
 | ------------ | ------- | --------- | ---------------------------- |
-| pid          | String  | yes       |                              |
+| id           | String  | yes       |                              |
 | title        | String  | yes       |                              |
 | creationDate | Date    | yes       |                              |
 | isPublic     | Boolean | yes       |                              |
+| pid          | String  | no        |                              |
 | size         | Integer | no        | Size of the dataset in bytes |
 
 ---
@@ -82,12 +101,12 @@ Represents a scientific proposal or publication.
 
 | Field       | Type    | Mandatory | Comment        |
 | ----------- | ------- | --------- | -------------- |
-| pid         | String  | yes       |                |
+| id          | String  | yes       |                |
 | type        | String  | yes       |                |
 | title       | String  | yes       |                |
+| pid         | String  | no        |                |
 | internal    | Boolean | no        |                |
 | summary     | String  | no        |                |
-| doi         | String  | no        |                |
 | startDate   | Date    | no        |                |
 | endDate     | Date    | no        |                |
 | releaseDate | Date    | no        |                |
@@ -109,7 +128,6 @@ Name of file and optionally location.
 
 | Field   | Type    | Mandatory | Comment         |
 | ------- | ------- | --------- | --------------- |
-| id      | String  | yes       |                 |
 | name    | String  | yes       |                 |
 | path    | String  | no        |                 |
 | size    | Integer | no        | Number of bytes |
@@ -130,9 +148,10 @@ Beam line where experiment took place.
 
 | Field    | Type    | Mandatory | Comment    |
 | -------- | ------- | --------- | ---------- |
-| id       | String  | yes       | e.g. a DOI |
+| id       | String  | yes       |            |
 | name     | String  | yes       | e.g. Loki  |
 | facility | String  | yes       | e.g. ESS   |
+| pid      | String  | no        |            |
 
 ---
 
@@ -192,11 +211,9 @@ Human who carried out experiment.
 
 | Field        | Type    | Mandatory | Comment  |
 | ------------ | ------- | --------- | -------- |
-| id           | String  | no        |          |
+| pid          | String  | no        |          |
 | name         | String  | no        |          |
 | surname      | String  | no        |          |
-| orcidId      | String  | no        |          |
-| researcherId | String  | no        |          |
 | publication  | String  | no        |          |
 
 ---
@@ -215,8 +232,9 @@ Extract of material used in the experiment.
 
 | Field       | Type    | Mandatory | Comment  |
 | ----------- | ------- | --------- | -------- |
+| id          | String  | yes       |          |
 | name        | String  | yes       |          |
-| doi         | String  | no        |          |
+| pid         | String  | no        |          |
 | description | String  | no        |          |
 
 ---
@@ -235,5 +253,5 @@ Common name of scientific method used.
 
 | Field | Type    | Mandatory | Comment  |
 | ----- | ------- | --------- | -------- |
-| pid   | String  | yes       |          |
 | name  | String  | yes       |          |
+| pid   | String  | no        |          |

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -1,3 +1,5 @@
+# The data model
+
 The data model consists of ten models
 * `Affiliation` - information about which facility a member is located at
 * `Dataset` - information about an experimental run, including optional File, Sample, Instrument and Technique
@@ -7,86 +9,231 @@ The data model consists of ten models
 * `Member` - proposal team member or paper co-author
 * `Parameter` - scalar measurement with value and units
 * `Person` - human who carried out experiment
-* `Role` - operator, author
 * `Sample` - extract of material used in the experiment
 * `Technique` - common name of scientific method used
 
-
 https://confluence.panosc.eu/display/wp3/Data+Model
+
+---
+
 ## Affiliation
 
-The `Affiliation` model has five optional fields
-* Id (string)
-* Name (string)
-* Address (string)
-* City (string)
-* Country (string)
+Information about which facility a member is located at.
+
+### Relationships
+
+| Card | Class  | Field  |
+| ---- | ------ | ------ |
+| 1,1  | Member | member |
+
+### Properties
+
+| Field   | Type   | Mandatory | Comment |
+| ------- | ------ | --------- | ------- |
+| id      | String | no        |         |
+| name    | String | no        |         |
+| address | String | no        |         |
+| city    | String | no        |         |
+| country | String | no        |         |
+
+---
 
 ## Dataset
-The `Dataset` model consists of 4 mandatory fields
-* Persistent Identifier or PID (string)
-* Title (string)
-* creation date (date)
-* isPublic (boolean)
 
-and an optional field
-* size (measurement with units(bytes))
+Information about an experimental run, including optional File,
+Sample, Instrument and Technique.
 
-The `Dataset` can have one `Instrument` only and several `Techniques`, `Parameters`, `Files` and `Samples`
+### Relationships
+
+| Card | Class      | Field      |
+| ---- | ---------- | ---------- |
+| 1,1  | Document   | document   |
+| 0,1  | Instrument | instrument |
+| 0,*  | File       | files      |
+| 0,*  | Parameter  | parameters |
+| 0,*  | Sample     | samples    |
+| 0,*  | Technique  | techniques |
+
+### Properties
+
+| Field        | Type    | Mandatory | Comment                      |
+| ------------ | ------- | --------- | ---------------------------- |
+| pid          | String  | yes       |                              |
+| title        | String  | yes       |                              |
+| creationDate | Date    | yes       |                              |
+| isPublic     | Boolean | yes       |                              |
+| size         | Integer | no        | Size of the dataset in bytes |
+
+---
 
 ## Document
-The `Document` model represents a scientific proposal or publication. It can include `Datasets`, `Parameters` and `Members`.
-It has three mandatory fields
-* PID
-* Type
-* title
 
-and seven optional fields
-* internal (Boolean)
-* summary (String)
-* DOI (string)
-* Start date (date)
-* end date (date)
-* release date (date)
-* license (string, e.g. CC-BY-4.0)
+Represents a scientific proposal or publication.
+
+### Relationships
+
+| Card | Class     | Field      |
+| ---- | --------- | ---------- |
+| 0,*  | Dataset   | datasets   |
+| 0,*  | Member    | members    |
+| 0,*  | Parameter | parameters |
+
+### Properties
+
+| Field       | Type    | Mandatory | Comment        |
+| ----------- | ------- | --------- | -------------- |
+| pid         | String  | yes       |                |
+| type        | String  | yes       |                |
+| title       | String  | yes       |                |
+| internal    | Boolean | no        |                |
+| summary     | String  | no        |                |
+| doi         | String  | no        |                |
+| startDate   | Date    | no        |                |
+| endDate     | Date    | no        |                |
+| releaseDate | Date    | no        |                |
+| license     | String  | no        | e.g. CC-BY-4.0 |
+
+---
 
 ## File
 
-The `File` model has two mandatory fields,
-* Id
-* name
+Name of file and optionally location.
 
-and two optional
-* path 
-* size
+### Relationships
+
+| Card | Class   | Field   |
+| ---- | ------- | ------- |
+| 1,1  | Dataset | dataset |
+
+### Properties
+
+| Field   | Type    | Mandatory | Comment         |
+| ------- | ------- | --------- | --------------- |
+| id      | String  | yes       |                 |
+| name    | String  | yes       |                 |
+| path    | String  | no        |                 |
+| size    | Integer | no        | Number of bytes |
+
+---
 
 ## Instrument
 
-The `Instrument` model has three mandatory fields, 
-* ID (string, e.g. a DOI)
-* Name (String, e.g. Loki)
-* Facility (string e.g. ESS)
+Beam line where experiment took place.
+
+### Relationships
+
+| Card | Class   | Field    |
+| ---- | ------- | -------- |
+| 0,*  | Dataset | datasets |
+
+### Properties
+
+| Field    | Type    | Mandatory | Comment    |
+| -------- | ------- | --------- | ---------- |
+| id       | String  | yes       | e.g. a DOI |
+| name     | String  | yes       | e.g. Loki  |
+| facility | String  | yes       | e.g. ESS   |
+
+---
 
 ## Member
 
+Proposal team member or paper co-author.
+
+### Relationships
+
+| Card | Class       | Field        |
+| ---- | ----------- | ------------ |
+| 1,1  | Document    | document     |
+| 1,1  | Person      | person       |
+| 0.*  | Affiliation | affiliations |
+
+### Properties
+
+| Field    | Type    | Mandatory | Comment |
+| -------- | ------- | --------- | ------- |
+| role     | String  | yes       |         |
+
+---
+
 ## Parameter
 
-The `Parameter` model is intended for scientific measurements. It has two mandatory fields
-* name (string, e.g. sample_pressure)
-* value (number e.g 22)
+### Relationships
 
-and one mandatory where applicable field
-* units (string e.g. bar)
+| Card | Class       | Field        |
+| ---- | ----------- | ------------ |
+| 0,1  | Dataset     | dataset      |
+| 0,1  | Document    | document     |
+
+Note: a parameter is either related to a dataset or a document, but
+not both.
+
+### Properties
+
+| Field    | Type    | Mandatory        | Comment              |
+| -------- | ------- | ---------------- | -------------------- |
+| name     | String  | yes              | e.g. sample_pressure |
+| value    | Number  | yes              | e.g. 22              |
+| units    | String  | where applicable | e.g. bar             |
+
+---
 
 ## Person
 
-## Role
+Human who carried out experiment.
 
+### Relationships
+
+| Card | Class  | Field   |
+| ---- | ------ | ------- |
+| 0,*  | Member | members |
+
+### Properties
+
+| Field        | Type    | Mandatory | Comment  |
+| ------------ | ------- | --------- | -------- |
+| id           | String  | no        |          |
+| name         | String  | no        |          |
+| surname      | String  | no        |          |
+| orcidId      | String  | no        |          |
+| researcherId | String  | no        |          |
+| publication  | String  | no        |          |
+
+---
+
+## Sample
+
+Extract of material used in the experiment.
+
+### Relationships
+
+| Card | Class   | Field    |
+| ---- | ------- | -------- |
+| 0,*  | Dataset | datasets |
+
+### Properties
+
+| Field       | Type    | Mandatory | Comment  |
+| ----------- | ------- | --------- | -------- |
+| name        | String  | yes       |          |
+| doi         | String  | no        |          |
+| description | String  | no        |          |
+
+---
 
 ## Technique
-The `Technique` model has two mandatory fields
-* PID (string)
-* name (string) 
 
+Common name of scientific method used.
 
-In general the API is readonly with no DELETE, POST/PUT or PATCH requests.
+### Relationships
+
+| Card | Class   | Field    |
+| ---- | ------- | -------- |
+| 0,*  | Dataset | datasets |
+
+### Properties
+
+| Field | Type    | Mandatory | Comment  |
+| ----- | ------- | --------- | -------- |
+| pid   | String  | yes       |          |
+| name  | String  | yes       |          |

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -48,8 +48,8 @@ Information about which facility a member is located at.
 
 | Field   | Type   | Mandatory | Comment |
 | ------- | ------ | --------- | ------- |
+| name    | String | yes       |         |
 | pid     | String | no        |         |
-| name    | String | no        |         |
 | address | String | no        |         |
 | city    | String | no        |         |
 | country | String | no        |         |
@@ -109,8 +109,8 @@ Represents a scientific proposal or publication.
 | summary     | String  | no        |                |
 | startDate   | Date    | no        |                |
 | endDate     | Date    | no        |                |
-| releaseDate | Date    | no        |                |
-| license     | String  | no        | e.g. CC-BY-4.0 |
+| releaseDate | Date    | no        | Date when this document will become openly accessible |
+| license     | String  | no        | Use [SPDX license identifier](http://www.spdx.org/licenses) if applicable, e.g. CC0-1.0 or CC-BY-4.0 |
 
 ---
 
@@ -191,7 +191,7 @@ not both.
 
 | Field    | Type    | Mandatory        | Comment              |
 | -------- | ------- | ---------------- | -------------------- |
-| name     | String  | yes              | e.g. sample_pressure |
+| name     | String  | yes              |                      |
 | value    | Number  | yes              | e.g. 22              |
 | units    | String  | where applicable | e.g. bar             |
 
@@ -211,9 +211,9 @@ Human who carried out experiment.
 
 | Field        | Type    | Mandatory | Comment  |
 | ------------ | ------- | --------- | -------- |
+| givenName    | String  | yes       |          |
+| familyName   | String  | yes       |          |
 | pid          | String  | no        |          |
-| name         | String  | no        |          |
-| surname      | String  | no        |          |
 | publication  | String  | no        |          |
 
 ---


### PR DESCRIPTION
Reformat and sanitize the data model documentation.

Changes for now:
* Reformat description with tables.
* Made the relationships explicit including their cardinality.
* Remove the Role class.  It was not in the diagram in the confluence page and I'm not sure what this was supposed to be.
* Add the missing description of the Sample class.
* Add several properties missing in the description.
* Sanitize identifiers with a clear distinction between (internal, ephemeral) ids and (persistent) pids.  Ref. also discussion in #19 concerning ids.
* Various cleanup: Affiliation.name mandatory, Renamed Person.name and Person.surname to less ambiguous Person.givenName and Person.familyName and made them mandatory, some comments.

There are several other issues that need discussion:
* Parameter values: we also have string values in some parameters, not only numbers. How to deal with that?
* The relation from Dataset to Instrument is restricted to only one Instrument. We have more then one Instrument involved in a single measurement. At BESSY II, we need to distinguish between beam lines and experimental stations, as the latter may be moved between beam lines.
* The relations from Dataset to Technique and Sample: the dataset is supposed to be "information about an experimental run". Does it make sense for a single experimental run to have several Samples and experimental Techniques?
* If we follow the argument from the last bullet, we might drop the Technique class and make that a property of Dataset.
* Why is there a relationship between Document and Parameter? What are document parameters supposed to be?
* There are several unclear or dubious properties:
  - what is Person.publication supposed to be and what is the value to have that property?
  - what is Document.internal supposed to be and what is the value to have that property?
  - what is Dataset.isPublic supposed to be and what is the value to have that property?
  - what is Document.type?
  - what is the value to have File.path? It only makes sense in the context of a given file system. But we do not have any file system at the level of the federated catalogue.
* Parameter.units: mandatory where applicable doesn't really make sense from an API specification point of view. Either it must be present, then it's mandatory or it is not mandatory.
* We might want to add a keywords property to Document, either a list of strings or a string of comma separated words.