### PR TITLE
Remove the "GET /datasets/{id}/metadata" call.

### DIFF
--- a/doc/api-calls.md
+++ b/doc/api-calls.md
@@ -12,29 +12,6 @@
 
 ## Dataset
 
-### Get metadata
-
-Get extended metadata for a dataset.
-
-#### Call
-
-`GET /datasets/{id}/metadata`
-
-#### Path parameters
-
-id
-: the id of the dataset
-
-#### Query parameters
-
-TBD
-
-#### Returns
-
-TBD
-
----
-
 ### Get dataset
 
 Get a single dataset.


### PR DESCRIPTION
As discussed in the meeting on Wednesday, the implementation of the "GET /datasets/{id}/metadata" call should be postponed for the time being.