### PR TITLE
Add Person.fullName, make Person.givenName and Person.familyName optional

### DIFF
--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -213,8 +213,9 @@ Human who carried out experiment.
 
 | Field       | Type   | Mandatory | Comment |
 | ----------- | ------ | --------- | ------- |
-| givenName   | String | yes       |         |
-| familyName  | String | yes       |         |
+| fullName    | String | yes       |         |
+| givenName   | String | no        |         |
+| familyName  | String | no        |         |
 | pid         | String | no        |         |
 | publication | String | no        |         |
 


### PR DESCRIPTION
As discussed in the meeting on Wednesday, `Person` should get a new mandatory property `fullName`. `givenName` and `familyName` should be optional.