### PR TITLE
Increase maximum depth of query object

### DIFF
--- a/server/datasources.json
+++ b/server/datasources.json
@@ -2,6 +2,7 @@
   "db": {
     "name": "db",
     "connector": "memory",
-    "file": "data/db.json"
+    "file": "data/db.json",
+    "maxDepthOfQuery": 16
   }
 }

--- a/server/datasources.json
+++ b/server/datasources.json
@@ -3,6 +3,6 @@
     "name": "db",
     "connector": "memory",
     "file": "data/db.json",
-    "maxDepthOfQuery": 16
+    "maxDepthOfQuery": 14
   }
 }


### PR DESCRIPTION
Hey! The default depth limit of query objects doesn't cut it. If you search documents by more than one parameter, the request fails if the parameters have value operators or array values.