### PR TITLE
Fix panet call when empty scope on relation

### DIFF
--- a/common/mixins/panet.js
+++ b/common/mixins/panet.js
@@ -71,8 +71,10 @@ module.exports = (Model) => {
         ctx.args.filter,
         "relation",
         (v) => v === "techniques",
-        async (obj) => (
-          obj.scope.where = await PanetOntology.panet(obj.scope.where))
+        async (obj) => {
+          if (obj.scope && obj.scope.where)
+            obj.scope.where = await PanetOntology.panet(obj.scope.where)
+        }
       )
     })
 }


### PR DESCRIPTION
Add if condition to check if PaNET ontology has to be called, depending if the filter has a scope.where condition non empty when using the technique relation. Add test for such use case